### PR TITLE
fix: フラッシュカードのモバイル横スクロール問題を修正

### DIFF
--- a/packages/web/app/features/flashcard/components/flashcard-item/flashcard-item.tsx
+++ b/packages/web/app/features/flashcard/components/flashcard-item/flashcard-item.tsx
@@ -281,7 +281,7 @@ export function FlashcardItem({
         isFlipped ? flashcard.answer : flashcard.question
       }. Enterでフリップ、矢印キーでスワイプ`}
       className={cn(
-        "relative w-80 aspect-square cursor-pointer select-none focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 rounded",
+        "relative w-80 aspect-square cursor-pointer select-none focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 rounded touch-pan-y",
         isDragging && "z-10",
         // アニメーション戻り時のみtransition適用
         isAnimatingBack && "transition-transform duration-300",


### PR DESCRIPTION
## Summary
- フラッシュカードコンポーネントに`touch-pan-y`クラスを追加
- モバイルサイズで横スクロールを無効化し、縦スクロールのみ許可
- カードの左右スワイプ体験を改善

## Test plan
- [ ] モバイル環境でフラッシュカード画面を開く
- [ ] カードを左右にスワイプして横スクロールが発生しないことを確認
- [ ] カードのスワイプ操作が正常に動作することを確認
- [ ] 縦スクロールは正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)