### PR TITLE
fix: 紙吹雪アニメーションのレイアウトシフト問題を修正

### DIFF
--- a/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
+++ b/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
@@ -105,11 +105,12 @@ export function FlashcardDeck({ flashcards, className }: Props) {
 
   if (isCompleted) {
     return (
-      <div className={cn("flex flex-col items-center space-y-6", className)}>
+      <>
         {/* 紙吹雪エフェクト */}
         <Confetti active={showCelebration} />
         
-        {/* 100%完了の進捗表示 */}
+        <div className={cn("flex flex-col items-center space-y-6", className)}>
+          {/* 100%完了の進捗表示 */}
         <div className="w-full max-w-md">
           <div className="flex justify-between text-sm text-gray-600 mb-2">
             <span>
@@ -154,7 +155,8 @@ export function FlashcardDeck({ flashcards, className }: Props) {
         >
           もう一度学習する
         </Button>
-      </div>
+        </div>
+      </>
     );
   }
 


### PR DESCRIPTION
## Summary
- 紙吹雪コンポーネントを親コンテナの外に配置してレイアウトシフトを修正
- アニメーション前後でタイトルとプログレスバーの間に余白が発生する問題を解決

## Test plan
- [ ] 学習完了時に紙吹雪アニメーションが正常に表示される
- [ ] アニメーション前後でレイアウトシフトが発生しない
- [ ] 紙吹雪が画面全体にfixed配置される

🤖 Generated with [Claude Code](https://claude.ai/code)