### PR TITLE
feat: コンテンツ一覧画面を新規実装

### DIFF
--- a/packages/web/app/features/content/components/content-list/content-list.stories.tsx
+++ b/packages/web/app/features/content/components/content-list/content-list.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ContentList } from "./content-list";
+import { GetSourcesResponse } from "@toi/shared/src/schemas/source";
+
+const meta: Meta<typeof ContentList> = {
+  title: "Features/Content/ContentList",
+  component: ContentList,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockContents: GetSourcesResponse = [
+  {
+    id: "1",
+    uid: "user1",
+    title: "React Hooksの基本",
+    content: "React Hooksは関数コンポーネントでstateやライフサイクルメソッドを使用するための仕組みです。useState、useEffect、useContextなどがあります。",
+    type: "TEXT",
+    isFlashcardGenerated: true,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "2",
+    uid: "user1",
+    title: "TypeScriptの型システム",
+    content: "TypeScriptは静的型付けをJavaScriptに追加した言語です。型安全性を高め、開発時のエラーを早期発見できます。",
+    type: "TEXT",
+    isFlashcardGenerated: false,
+    createdAt: "2024-01-02T00:00:00Z",
+    updatedAt: "2024-01-02T00:00:00Z",
+  },
+  {
+    id: "3",
+    uid: "user1",
+    title: "CSS GridとFlexboxの違い",
+    content: "CSS Gridは2次元レイアウト、Flexboxは1次元レイアウトに適しています。用途に応じて使い分けることが重要です。",
+    type: "TEXT",
+    isFlashcardGenerated: true,
+    createdAt: "2024-01-03T00:00:00Z",
+    updatedAt: "2024-01-03T00:00:00Z",
+  },
+  {
+    id: "4",
+    uid: "user1",
+    content: "無題のコンテンツです。タイトルが設定されていないコンテンツの例です。",
+    type: "TEXT",
+    isFlashcardGenerated: false,
+    createdAt: "2024-01-04T00:00:00Z",
+    updatedAt: "2024-01-04T00:00:00Z",
+  },
+];
+
+export const Default: Story = {
+  args: {
+    contents: mockContents,
+    isLoading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    contents: [],
+    isLoading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    contents: [],
+    isLoading: false,
+  },
+};
+
+export const SingleItem: Story = {
+  args: {
+    contents: [mockContents[0]],
+    isLoading: false,
+  },
+};
+
+export const WithoutFlashcards: Story = {
+  args: {
+    contents: mockContents.map(content => ({
+      ...content,
+      isFlashcardGenerated: false,
+    })),
+    isLoading: false,
+  },
+};
+
+export const WithLongContent: Story = {
+  args: {
+    contents: [
+      {
+        id: "long-1",
+        uid: "user1",
+        title: "非常に長いタイトルの例：React、TypeScript、Next.js、Tailwind CSSを使った現代的なWebアプリケーション開発について",
+        content: "非常に長いコンテンツの例です。このコンテンツは複数行にわたって表示され、text-overflow: ellipsisによって適切に省略されることを確認するためのものです。実際のアプリケーションでは、ユーザーが入力したテキストが想定よりも長くなる場合があるため、このような表示の調整が重要になります。適切な省略処理により、ユーザーインターフェースの一貫性を保つことができます。",
+        type: "TEXT",
+        isFlashcardGenerated: true,
+        createdAt: "2024-01-05T00:00:00Z",
+        updatedAt: "2024-01-05T00:00:00Z",
+      },
+    ],
+    isLoading: false,
+  },
+};

--- a/packages/web/app/features/content/components/content-list/content-list.test.tsx
+++ b/packages/web/app/features/content/components/content-list/content-list.test.tsx
@@ -1,0 +1,103 @@
+/// <reference types="vitest/globals" />
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { ContentList } from "./content-list";
+import { GetSourcesResponse } from "@toi/shared/src/schemas/source";
+
+const mockContents: GetSourcesResponse = [
+  {
+    id: "1",
+    uid: "user1",
+    title: "テストタイトル1",
+    content: "テストコンテンツ1の内容です。これはテスト用のコンテンツです。",
+    type: "TEXT",
+    isFlashcardGenerated: true,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "2",
+    uid: "user1",
+    title: "テストタイトル2",
+    content: "テストコンテンツ2の内容です。",
+    type: "TEXT",
+    isFlashcardGenerated: false,
+    createdAt: "2024-01-02T00:00:00Z",
+    updatedAt: "2024-01-02T00:00:00Z",
+  },
+  {
+    id: "3",
+    uid: "user1",
+    content: "タイトルなしのコンテンツです。",
+    type: "TEXT",
+    isFlashcardGenerated: false,
+    createdAt: "2024-01-03T00:00:00Z",
+    updatedAt: "2024-01-03T00:00:00Z",
+  },
+];
+
+const renderWithRouter = (component: React.ReactElement) => {
+  return render(<BrowserRouter>{component}</BrowserRouter>);
+};
+
+describe("ContentList", () => {
+  it("コンテンツが正しく表示される", () => {
+    renderWithRouter(<ContentList contents={mockContents} />);
+
+    expect(screen.getByText("テストタイトル1")).toBeInTheDocument();
+    expect(screen.getByText("テストタイトル2")).toBeInTheDocument();
+    expect(screen.getByText("無題")).toBeInTheDocument();
+    
+    expect(screen.getByText("テストコンテンツ1の内容です。これはテスト用のコンテンツです。")).toBeInTheDocument();
+    expect(screen.getByText("テストコンテンツ2の内容です。")).toBeInTheDocument();
+    expect(screen.getByText("タイトルなしのコンテンツです。")).toBeInTheDocument();
+  });
+
+  it("フラッシュカード生成済みの表示が正しい", () => {
+    renderWithRouter(<ContentList contents={mockContents} />);
+
+    expect(screen.getByText("フラッシュカード生成済み")).toBeInTheDocument();
+    expect(screen.getByText("学習")).toBeInTheDocument();
+  });
+
+  it("詳細リンクが正しく表示される", () => {
+    renderWithRouter(<ContentList contents={mockContents} />);
+
+    const detailLinks = screen.getAllByText("詳細");
+    expect(detailLinks).toHaveLength(3);
+    
+    expect(detailLinks[0].closest("a")).toHaveAttribute("href", "/content/1");
+    expect(detailLinks[1].closest("a")).toHaveAttribute("href", "/content/2");
+    expect(detailLinks[2].closest("a")).toHaveAttribute("href", "/content/3");
+  });
+
+  it("学習リンクはフラッシュカード生成済みのコンテンツにのみ表示される", () => {
+    renderWithRouter(<ContentList contents={mockContents} />);
+
+    const learningLinks = screen.getAllByText("学習");
+    expect(learningLinks).toHaveLength(1);
+    expect(learningLinks[0].closest("a")).toHaveAttribute("href", "/content/1/flashcards");
+  });
+
+  it("ローディング状態が正しく表示される", () => {
+    renderWithRouter(<ContentList contents={[]} isLoading={true} />);
+
+    const skeletonCards = document.querySelectorAll(".animate-pulse");
+    expect(skeletonCards).toHaveLength(6);
+  });
+
+  it("コンテンツが空の場合、空状態が表示される", () => {
+    renderWithRouter(<ContentList contents={[]} />);
+
+    expect(screen.getByText("まだコンテンツがありません")).toBeInTheDocument();
+    expect(screen.getByText("新しいコンテンツを作る")).toBeInTheDocument();
+    expect(screen.getByText("新しいコンテンツを作る").closest("a")).toHaveAttribute("href", "/content/new");
+  });
+
+  it("コンテンツタイプが表示される", () => {
+    renderWithRouter(<ContentList contents={mockContents} />);
+
+    const typeLabels = screen.getAllByText("TEXT");
+    expect(typeLabels).toHaveLength(3);
+  });
+});

--- a/packages/web/app/features/content/components/content-list/content-list.tsx
+++ b/packages/web/app/features/content/components/content-list/content-list.tsx
@@ -1,0 +1,74 @@
+import { Link } from "@remix-run/react";
+import { Card } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { GetSourcesResponse } from "@toi/shared/src/schemas/source";
+
+export type ContentListProps = {
+  contents: GetSourcesResponse;
+  isLoading?: boolean;
+};
+
+export function ContentList({ contents, isLoading = false }: ContentListProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <Card key={index} className="h-48 p-6 animate-pulse">
+            <div className="h-4 bg-gray-200 rounded mb-2"></div>
+            <div className="h-3 bg-gray-200 rounded mb-4"></div>
+            <div className="h-3 bg-gray-200 rounded mb-4"></div>
+            <div className="mt-auto h-10 bg-gray-200 rounded"></div>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (contents.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground mb-4">
+          まだコンテンツがありません
+        </p>
+        <Button asChild>
+          <Link to="/content/new">新しいコンテンツを作る</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {contents.map((content) => (
+        <Card key={content.id} className="h-48 p-6 flex flex-col">
+          <div className="flex-1">
+            <h3 className="font-bold mb-2 line-clamp-2">
+              {content.title || "無題"}
+            </h3>
+            <p className="text-sm text-muted-foreground mb-4 line-clamp-3">
+              {content.content}
+            </p>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span>{content.type}</span>
+              {content.isFlashcardGenerated && (
+                <span className="bg-green-100 text-green-800 px-2 py-1 rounded">
+                  フラッシュカード生成済み
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="mt-4 flex gap-2">
+            <Button variant="outline" size="sm" asChild className="flex-1">
+              <Link to={`/content/${content.id}`}>詳細</Link>
+            </Button>
+            {content.isFlashcardGenerated && (
+              <Button size="sm" asChild className="flex-1">
+                <Link to={`/content/${content.id}/flashcards`}>学習</Link>
+              </Button>
+            )}
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/app/features/content/components/content-list/index.ts
+++ b/packages/web/app/features/content/components/content-list/index.ts
@@ -1,0 +1,2 @@
+export { ContentList } from "./content-list";
+export type { ContentListProps } from "./content-list";

--- a/packages/web/app/features/content/components/index.ts
+++ b/packages/web/app/features/content/components/index.ts
@@ -11,3 +11,4 @@ export { InputArea } from "./input-area";
 export { ContentCreationHeader } from "./content-creation-header";
 export { PlanIndicator } from "./plan-indicator";
 export { ContentCreationButton } from "./content-creation-button";
+export { ContentList, type ContentListProps } from "./content-list";

--- a/packages/web/app/routes/_content.contents.tsx
+++ b/packages/web/app/routes/_content.contents.tsx
@@ -1,0 +1,36 @@
+import { json } from "@remix-run/node";
+import { useLoaderData, Link } from "@remix-run/react";
+import { ContentList } from "~/features/content/components/content-list";
+import { getSources } from "~/services/sources";
+import { Button } from "~/components/ui/button";
+
+export async function loader() {
+  try {
+    const sources = await getSources();
+    return json({ sources });
+  } catch (error) {
+    console.error("Failed to load sources:", error);
+    return json({ sources: [] });
+  }
+}
+
+export default function ContentsPage() {
+  const { sources } = useLoaderData<typeof loader>();
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="flex justify-between items-center mb-6">
+        <div>
+          <h1 className="text-3xl font-bold">コンテンツ一覧</h1>
+          <p className="text-muted-foreground mt-2">
+            作成したコンテンツを確認・学習できます
+          </p>
+        </div>
+        <Button asChild>
+          <Link to="/content/new">新しいコンテンツを作る</Link>
+        </Button>
+      </div>
+      <ContentList contents={sources} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- コンテンツ一覧画面（/contents）を新規実装
- ContentListコンポーネントの作成とテスト
- フラッシュカード生成状態の表示機能
- 空状態とローディング状態の適切な表示

## Test plan
- [ ] /contentsページが正しく表示される
- [ ] コンテンツカードが適切にレンダリングされる
- [ ] フラッシュカード生成済みの表示が正しい
- [ ] 詳細・学習リンクが正しく動作する
- [ ] 空状態が適切に表示される
- [ ] ローディング状態が適切に表示される
- [ ] テストが通る
- [ ] Storybookストーリーが正しく表示される

🤖 Generated with [Claude Code](https://claude.ai/code)