### PR TITLE
feat: アカウント情報ダイアログを追加

### DIFF
--- a/packages/web/app/components/layout/account-info-dialog/account-info-dialog.stories.tsx
+++ b/packages/web/app/components/layout/account-info-dialog/account-info-dialog.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import AccountInfoDialog from "./account-info-dialog";
+
+const meta: Meta<typeof AccountInfoDialog> = {
+  title: "Layout/AccountInfoDialog",
+  component: AccountInfoDialog,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof AccountInfoDialog>;
+
+function DialogDemo() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div>
+      <Button onClick={() => setIsOpen(true)}>
+        アカウント情報を開く
+      </Button>
+      <AccountInfoDialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <DialogDemo />,
+};

--- a/packages/web/app/components/layout/account-info-dialog/account-info-dialog.tsx
+++ b/packages/web/app/components/layout/account-info-dialog/account-info-dialog.tsx
@@ -1,0 +1,69 @@
+import { ComponentPropsWithoutRef } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { User, CreditCard, Settings, LogOut } from "lucide-react";
+import { Button } from "~/components/ui/button";
+
+type AccountInfoDialogProps = ComponentPropsWithoutRef<typeof Dialog> & {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+function AccountInfoDialog({ isOpen, onClose, ...props }: AccountInfoDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose} {...props}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>アカウント情報</DialogTitle>
+        </DialogHeader>
+        
+        <div className="space-y-6">
+          {/* ユーザー情報 */}
+          <div className="flex items-center space-x-4">
+            <div className="flex-shrink-0 w-12 h-12 bg-muted-foreground/20 rounded-full flex items-center justify-center">
+              <User className="w-6 h-6" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="text-sm font-medium">Kazuvin</h3>
+              <p className="text-sm text-muted-foreground">kazuvin@example.com</p>
+            </div>
+          </div>
+
+          {/* プラン情報 */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">プラン</span>
+              <span className="text-sm text-muted-foreground">無料プラン</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">使用量</span>
+              <span className="text-sm text-muted-foreground">5 / 10 コンテンツ</span>
+            </div>
+          </div>
+
+          {/* アクションボタン */}
+          <div className="space-y-2">
+            <Button variant="outline" className="w-full justify-start" size="sm">
+              <CreditCard className="w-4 h-4 mr-2" />
+              プランをアップグレード
+            </Button>
+            <Button variant="outline" className="w-full justify-start" size="sm">
+              <Settings className="w-4 h-4 mr-2" />
+              設定
+            </Button>
+            <Button variant="outline" className="w-full justify-start text-destructive hover:text-destructive" size="sm">
+              <LogOut className="w-4 h-4 mr-2" />
+              ログアウト
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default AccountInfoDialog;

--- a/packages/web/app/components/layout/account-info-dialog/index.ts
+++ b/packages/web/app/components/layout/account-info-dialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./account-info-dialog";

--- a/packages/web/app/components/layout/mobile-sidebar/mobile-sidebar.tsx
+++ b/packages/web/app/components/layout/mobile-sidebar/mobile-sidebar.tsx
@@ -1,11 +1,12 @@
 import { cn } from "~/lib/utils";
-import { ComponentPropsWithoutRef, useEffect } from "react";
+import { ComponentPropsWithoutRef, useEffect, useState } from "react";
 import { User, X, MessageSquare, PlusCircle } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { Link } from "@remix-run/react";
 import useSWR from "swr";
 import { getSources } from "~/services/sources";
 import { Spinner } from "../../ui/spinner/spinner";
+import AccountInfoDialog from "../account-info-dialog";
 
 type SidebarItemProps = {
   children: React.ReactNode;
@@ -20,17 +21,17 @@ type MobileSidebarProps = ComponentPropsWithoutRef<"aside"> & {
   onClose: () => void;
 };
 
-function AccountInfo() {
+function AccountInfo({ onAccountClick }: { onAccountClick: () => void }) {
   return (
     <div className="flex items-center gap-sm py-sm min-w-0">
-      <Link
-        to="/account"
-        className="p-2 bg-muted-foreground/20 rounded-sm transition-colors flex-shrink-0"
+      <button
+        onClick={onAccountClick}
+        className="p-2 bg-muted-foreground/20 rounded-sm transition-colors flex-shrink-0 hover:bg-muted-foreground/30"
       >
         <div className="size-4 flex items-center justify-center">
           <User className="size-4" />
         </div>
-      </Link>
+      </button>
       <div className="min-w-0 flex-1">
         <p className="text-sm font-medium truncate">Kazuvin</p>
         <p className="text-xs text-muted-foreground truncate">無料プラン</p>
@@ -72,6 +73,7 @@ function MobileSidebar({
   ...props
 }: MobileSidebarProps) {
   const { data: sources } = useSWR("/api/sources", getSources);
+  const [isAccountDialogOpen, setIsAccountDialogOpen] = useState(false);
 
   // モバイルサイドバーが開いている時はbodyのスクロールを無効化
   useEffect(() => {
@@ -171,9 +173,14 @@ function MobileSidebar({
         </div>
 
         <div className="mt-auto flex-shrink-0">
-          <AccountInfo />
+          <AccountInfo onAccountClick={() => setIsAccountDialogOpen(true)} />
         </div>
       </aside>
+
+      <AccountInfoDialog
+        isOpen={isAccountDialogOpen}
+        onClose={() => setIsAccountDialogOpen(false)}
+      />
     </>
   );
 }

--- a/packages/web/app/components/layout/sidebar/sidebar.tsx
+++ b/packages/web/app/components/layout/sidebar/sidebar.tsx
@@ -11,22 +11,24 @@ import { Link } from "@remix-run/react";
 import useSWR from "swr";
 import { getSources } from "~/services/sources";
 import { Spinner } from "~/components/ui/spinner";
+import AccountInfoDialog from "../account-info-dialog";
 
 type AccountInfoProps = ComponentPropsWithoutRef<"div"> & {
   isOpen: boolean;
+  onAccountClick: () => void;
 };
 
-function AccountInfo({ isOpen }: AccountInfoProps) {
+function AccountInfo({ isOpen, onAccountClick }: AccountInfoProps) {
   return (
     <div className="flex items-center gap-sm py-sm min-w-0">
-      <Link
-        to="/account"
-        className="p-2 bg-muted-foreground/20 rounded-sm transition-colors flex-shrink-0"
+      <button
+        onClick={onAccountClick}
+        className="p-2 bg-muted-foreground/20 rounded-sm transition-colors flex-shrink-0 hover:bg-muted-foreground/30"
       >
         <div className="size-4 flex items-center justify-center">
           <User className="size-4" />
         </div>
-      </Link>
+      </button>
       <div
         className={cn(
           "transition-opacity duration-300 min-w-0 flex-1",
@@ -92,6 +94,7 @@ type SidebarProps = ComponentPropsWithoutRef<"aside"> & {
 
 export default function Sidebar({ className, ...props }: SidebarProps) {
   const [isOpen, setIsOpen] = useState(true);
+  const [isAccountDialogOpen, setIsAccountDialogOpen] = useState(false);
   const { data: sources } = useSWR("/api/sources", getSources);
 
   return (
@@ -171,8 +174,16 @@ export default function Sidebar({ className, ...props }: SidebarProps) {
       </div>
 
       <div className="flex items-center mt-auto h-16">
-        <AccountInfo isOpen={isOpen} />
+        <AccountInfo 
+          isOpen={isOpen} 
+          onAccountClick={() => setIsAccountDialogOpen(true)}
+        />
       </div>
+
+      <AccountInfoDialog
+        isOpen={isAccountDialogOpen}
+        onClose={() => setIsAccountDialogOpen(false)}
+      />
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- サイドバーとモバイルサイドバーのアカウント情報をクリックで表示できるダイアログコンポーネントを実装
- ui/dialogコンポーネントを使用した仮のアカウント情報ダイアログを作成
- ユーザー情報、プラン情報、アクションボタンを含む設計

## Changes
- `account-info-dialog` コンポーネントを新規作成
- デスクトップサイドバーにダイアログ表示機能を実装
- モバイルサイドバーにダイアログ表示機能を実装
- Storybookストーリーを追加

## Test plan
- [ ] デスクトップサイドバーのアカウント情報をクリックしてダイアログが表示されることを確認
- [ ] モバイルサイドバーのアカウント情報をクリックしてダイアログが表示されることを確認
- [ ] ダイアログが正しく閉じることを確認
- [ ] lint/typecheckが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)