### PR TITLE
feat: WebサイトのURLから学習コンテンツ(フラッシュカード)を生成する機能を追加

### DIFF
--- a/packages/api/src/routes/sources.ts
+++ b/packages/api/src/routes/sources.ts
@@ -17,6 +17,7 @@ import {
   PutSourceDetailResponse,
 } from "@toi/shared/src/schemas/source";
 import { ZodError } from "zod";
+import urlRoute from "./sources/url";
 
 type Bindings = {
   DB: D1Database;
@@ -122,5 +123,7 @@ app
 
     return c.json(response);
   });
+
+app.route("/url", urlRoute);
 
 export default app;

--- a/packages/api/src/routes/sources/url.ts
+++ b/packages/api/src/routes/sources/url.ts
@@ -1,0 +1,35 @@
+import { Hono } from "hono";
+import { nanoid } from "nanoid";
+import { zValidator } from "@hono/zod-validator";
+import { PostSourceFromUrlBodySchema } from "@toi/shared";
+import { Database } from "../../index";
+import { insertSource } from "../../services/sources";
+import { fetchContentFromUrl } from "../../services/url-content";
+
+const app = new Hono<{ Bindings: Database }>();
+
+app.post("/", zValidator("json", PostSourceFromUrlBodySchema), async (c) => {
+  const body = c.req.valid("json");
+  const uid = c.get("uid");
+
+  try {
+    // URLからコンテンツを取得
+    const textContent = await fetchContentFromUrl(body.url);
+
+    // ソースを作成
+    const sourceId = nanoid();
+    const source = await insertSource(c.env.DB, {
+      id: sourceId,
+      uid,
+      content: textContent,
+      type: "TEXT" as const,
+    });
+
+    return c.json(source);
+  } catch (error) {
+    console.error("URL処理エラー:", error);
+    return c.json({ error: "URLの処理中にエラーが発生しました" }, 500);
+  }
+});
+
+export default app;

--- a/packages/api/src/services/sources.ts
+++ b/packages/api/src/services/sources.ts
@@ -1,4 +1,4 @@
-import { DrizzleD1Database } from "drizzle-orm/d1";
+import { DrizzleD1Database, drizzle } from "drizzle-orm/d1";
 import { source } from "@/db/schemas";
 import { PostSourceBody, PutSourceBody } from "@toi/shared/src/schemas/source";
 import { eq } from "drizzle-orm";
@@ -23,6 +23,30 @@ export const createSource = async (
       type: data.type,
     })
     .returning();
+};
+
+export const insertSource = async (
+  db: D1Database,
+  data: {
+    id: string;
+    uid?: string;
+    content: string;
+    type: "TEXT";
+    title?: string;
+  }
+) => {
+  const drizzleDb = drizzle(db);
+  return await drizzleDb
+    .insert(source)
+    .values({
+      id: data.id,
+      uid: data.uid,
+      content: data.content,
+      type: data.type,
+      title: data.title,
+    })
+    .returning()
+    .then((result) => result[0]);
 };
 
 export const updateSource = async (

--- a/packages/api/src/services/url-content.ts
+++ b/packages/api/src/services/url-content.ts
@@ -1,0 +1,62 @@
+export async function fetchContentFromUrl(url: string): Promise<string> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const html = await response.text();
+    
+    // HTML から本文テキストを抽出
+    const textContent = extractTextFromHtml(html);
+    
+    if (!textContent.trim()) {
+      throw new Error("テキストコンテンツが見つかりませんでした");
+    }
+
+    return textContent;
+  } catch (error) {
+    console.error("URL コンテンツ取得エラー:", error);
+    throw error;
+  }
+}
+
+function extractTextFromHtml(html: string): string {
+  // script と style タグを削除
+  let content = html
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
+
+  // 主要コンテンツエリアを優先的に抽出
+  const contentSelectors = [
+    /<main[^>]*>([\s\S]*?)<\/main>/gi,
+    /<article[^>]*>([\s\S]*?)<\/article>/gi,
+    /<div[^>]*class="[^"]*content[^"]*"[^>]*>([\s\S]*?)<\/div>/gi,
+    /<div[^>]*class="[^"]*post[^"]*"[^>]*>([\s\S]*?)<\/div>/gi,
+  ];
+
+  let extractedContent = '';
+  for (const selector of contentSelectors) {
+    const matches = content.match(selector);
+    if (matches && matches.length > 0) {
+      extractedContent = matches.join(' ');
+      break;
+    }
+  }
+
+  // メインコンテンツが見つからない場合は全体を使用
+  if (!extractedContent) {
+    extractedContent = content;
+  }
+
+  // HTMLタグを削除
+  extractedContent = extractedContent.replace(/<[^>]*>/g, '');
+  
+  // 空白文字を正規化
+  extractedContent = extractedContent
+    .replace(/\s+/g, ' ')
+    .replace(/\n+/g, '\n')
+    .trim();
+
+  return extractedContent;
+}

--- a/packages/shared/src/schemas/source.ts
+++ b/packages/shared/src/schemas/source.ts
@@ -50,9 +50,21 @@ export const PostSourceBodySchema = z.object({
 });
 
 /**
+ * URL からソース作成 (POST) のリクエストボディスキーマ
+ */
+export const PostSourceFromUrlBodySchema = z.object({
+  url: z.string().url(),
+});
+
+/**
  * ソース作成 (POST) のリクエストボディの型
  */
 export type PostSourceBody = z.infer<typeof PostSourceBodySchema>;
+
+/**
+ * URL からソース作成 (POST) のリクエストボディの型
+ */
+export type PostSourceFromUrlBody = z.infer<typeof PostSourceFromUrlBodySchema>;
 
 /**
  * ソース作成 (POST) のレスポンススキーマ

--- a/packages/web/app/features/content/hooks/use-content-creation/use-content-creation.ts
+++ b/packages/web/app/features/content/hooks/use-content-creation/use-content-creation.ts
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { mutate } from "swr";
 import { useNavigate } from "@remix-run/react";
 import { toast } from "sonner";
-import { createSource } from "~/services/sources";
+import { createSource, createSourceFromUrl } from "~/services/sources";
 import type { OutputFormatType } from "../use-output-formats";
 import { postFlashcard } from "~/services/flashcard";
 import { postTitle } from "~/services/source";
@@ -13,7 +13,8 @@ export function useContentCreation() {
 
   const createContent = async (
     content: string,
-    selectedFormats: OutputFormatType[]
+    selectedFormats: OutputFormatType[],
+    inputMethod: "text" | "file" | "website" | "youtube" = "text"
   ) => {
     if (!content || selectedFormats.length === 0) {
       return;
@@ -21,11 +22,19 @@ export function useContentCreation() {
 
     setIsLoading(true);
     try {
-      // ソースを作成
-      const response = await createSource({
-        content,
-        type: "TEXT",
-      });
+      let response;
+      
+      // 入力方法に応じてソースを作成
+      if (inputMethod === "website") {
+        // URLからソースを作成
+        response = await createSourceFromUrl({ url: content });
+      } else {
+        // テキストまたはファイルからソースを作成
+        response = await createSource({
+          content,
+          type: "TEXT",
+        });
+      }
 
       // ソースのタイトルを更新
       await postTitle({ sourceId: response.id });

--- a/packages/web/app/routes/_content.new.tsx
+++ b/packages/web/app/routes/_content.new.tsx
@@ -24,7 +24,7 @@ export default function ContentNew() {
 
   const handleCreateContent = async () => {
     // TODO: 出力形式を選択できるようにする
-    await createContent(inputText, ["flashcard"]);
+    await createContent(inputText, ["flashcard"], inputMethod);
   };
 
   return (

--- a/packages/web/app/services/sources.ts
+++ b/packages/web/app/services/sources.ts
@@ -5,6 +5,7 @@ import {
   PutSourceDetailResponse,
   PostSourceBody,
   PostSourceDetailResponse,
+  PostSourceFromUrlBody,
 } from "@toi/shared/src/schemas/source";
 import { api } from "./base";
 
@@ -22,4 +23,8 @@ export const updateSource = async (id: string, body: PutSourceBody) => {
 
 export const createSource = async (body: PostSourceBody) => {
   return api.post<PostSourceDetailResponse>("/sources", body);
+};
+
+export const createSourceFromUrl = async (body: PostSourceFromUrlBody) => {
+  return api.post<PostSourceDetailResponse>("/sources/url", body);
 };


### PR DESCRIPTION
## Summary
- URLからコンテンツを取得するAPI エンドポイントを追加 (/sources/url)
- HTMLからテキストコンテンツを抽出する機能を実装
- フロントエンドでWebsite入力方法を選択した場合の処理を追加

## Test plan
- [ ] URLからコンテンツを取得できることを確認
- [ ] HTMLからテキストが正しく抽出されることを確認
- [ ] フロントエンドでWebサイトを選択してフラッシュカードが生成されることを確認
- [ ] 既存のテキスト入力機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)