### PR TITLE
feat: 学習コンテンツの成功・失敗時にsonnerトースト通知を追加

### DIFF
--- a/packages/web/app/features/content/hooks/use-content-creation/use-content-creation.ts
+++ b/packages/web/app/features/content/hooks/use-content-creation/use-content-creation.ts
@@ -27,15 +27,22 @@ export function useContentCreation() {
       // 入力方法に応じてソースを作成
       if (inputMethod === "website") {
         // URLからソースを作成
+        toast.loading("Webサイトからコンテンツを取得中...", { id: "content-creation" });
         response = await createSourceFromUrl({ url: content });
+        toast.success("Webサイトからコンテンツを取得しました", { id: "content-creation" });
       } else {
         // テキストまたはファイルからソースを作成
+        toast.loading("コンテンツを処理中...", { id: "content-creation" });
         response = await createSource({
           content,
           type: "TEXT",
         });
+        toast.success("コンテンツを作成しました", { id: "content-creation" });
       }
 
+      // タイトル生成とフラッシュカード作成
+      toast.loading("タイトルとフラッシュカードを生成中...", { id: "content-creation" });
+      
       // ソースのタイトルを更新
       await postTitle({ sourceId: response.id });
 
@@ -45,9 +52,29 @@ export function useContentCreation() {
       // ソース一覧を更新
       mutate("/api/sources");
 
+      // 成功通知
+      toast.success("学習コンテンツが正常に作成されました！フラッシュカードの学習を開始できます。", { 
+        id: "content-creation",
+        duration: 5000 
+      });
+
       navigate(`/content/${response.id}/flashcards`);
     } catch (error) {
-      toast.error("学習コンテンツの作成に失敗しました");
+      // エラーメッセージをより詳細に
+      let errorMessage = "学習コンテンツの作成に失敗しました";
+      
+      if (error instanceof Error) {
+        if (error.message.includes("URL")) {
+          errorMessage = "URLからコンテンツを取得できませんでした。URLが正しいか確認してください。";
+        } else if (error.message.includes("network")) {
+          errorMessage = "ネットワークエラーが発生しました。インターネット接続を確認してください。";
+        }
+      }
+      
+      toast.error(errorMessage, { 
+        id: "content-creation",
+        duration: 6000 
+      });
       console.error(error);
     } finally {
       setIsLoading(false);

--- a/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
+++ b/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { toast } from "sonner";
 import { cn } from "~/lib/utils";
 import { Button } from "~/components/ui/button";
 import { FlashcardItem } from "../flashcard-item";
@@ -52,6 +53,24 @@ export function FlashcardDeck({ flashcards, className }: Props) {
         // 最後のカードの場合は完了状態に移行
         setCurrentIndex(flashcards.length);
         setShowCelebration(true);
+        
+        // 完了トースト通知
+        const okCount = Object.values(completedCards).filter((v) => v === "ok").length + (completedCards[flashcards[currentIndex]?.id] === "ok" ? 0 : 1);
+        const accuracy = Math.round((okCount / flashcards.length) * 100);
+        
+        if (accuracy >= 80) {
+          toast.success(`🎉 素晴らしい！${flashcards.length}枚の学習を完了しました（正解率: ${accuracy}%）`, {
+            duration: 6000,
+          });
+        } else if (accuracy >= 60) {
+          toast.success(`👏 よくできました！${flashcards.length}枚の学習を完了しました（正解率: ${accuracy}%）`, {
+            duration: 6000,
+          });
+        } else {
+          toast.success(`📚 学習完了！もう一度チャレンジしてみましょう（正解率: ${accuracy}%）`, {
+            duration: 6000,
+          });
+        }
       } else {
         // 次のカードに移動
         setCurrentIndex(currentIndex + 1);

--- a/packages/web/app/root.tsx
+++ b/packages/web/app/root.tsx
@@ -9,7 +9,6 @@ import type { LinksFunction } from "@remix-run/node";
 
 import "./tailwind.css";
 import Provider from "./provider";
-import { Toaster } from "./components/ui/toaster";
 
 export const links: LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -46,7 +45,6 @@ export default function App() {
   return (
     <Provider>
       <Outlet />
-      <Toaster />
     </Provider>
   );
 }

--- a/packages/web/app/routes/_content.content.$id_.flashcards.tsx
+++ b/packages/web/app/routes/_content.content.$id_.flashcards.tsx
@@ -1,9 +1,11 @@
 import { useParams } from "@remix-run/react";
 import useSWR from "swr";
+import { toast } from "sonner";
 import { getFlashcardsBySourceId } from "~/services/flashcard";
 import { FlashcardDeck } from "~/features/flashcard/components";
 import { Spinner } from "~/components/ui/spinner";
 import { useContentDetail } from "~/features/content";
+import { useEffect } from "react";
 
 export default function ContentFlashcards() {
   const { id } = useParams();
@@ -19,6 +21,24 @@ export default function ContentFlashcards() {
       revalidateOnFocus: false,
     }
   );
+
+  // エラー時のトースト通知
+  useEffect(() => {
+    if (error) {
+      toast.error("フラッシュカードの読み込みに失敗しました。ページを再読み込みしてください。", {
+        duration: 6000,
+      });
+    }
+  }, [error]);
+
+  // フラッシュカードがない場合の通知
+  useEffect(() => {
+    if (data && (!data.flashcards || data.flashcards.length === 0)) {
+      toast.info("このコンテンツにはまだフラッシュカードが作成されていません。", {
+        duration: 4000,
+      });
+    }
+  }, [data]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- 学習コンテンツ作成・学習プロセス全体でsonnerトースト通知を追加
- ユーザー体験を向上させるための詳細なフィードバック機能を実装

## Changes

### コンテンツ作成時の通知
- **進行状況表示**: URL取得、コンテンツ処理、タイトル・フラッシュカード生成の各段階でloading状態を表示
- **成功通知**: 各段階の完了と最終的な成功メッセージを表示
- **詳細エラー**: URLエラー、ネットワークエラーなど具体的なエラーメッセージに改善
- **トースト管理**: 同一IDを使用して進行状況を段階的に更新

### フラッシュカード学習時の通知
- **学習完了通知**: 正解率に応じた3段階のお祝いメッセージ（80%以上、60%以上、60%未満）
- **読み込みエラー通知**: フラッシュカード取得失敗時の通知
- **データなし通知**: フラッシュカードが存在しない場合の情報通知

### 技術的改善
- 重複するToasterコンポーネントを削除（root.tsx）
- 一貫したトースト表示期間の設定
- エラーハンドリングの改善

## Test plan
- [x] コンテンツ作成成功時のトースト表示を確認
- [x] URL取得エラー時のトースト表示を確認
- [x] フラッシュカード学習完了時のトースト表示を確認
- [x] build、lint、typecheckが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)