### PR TITLE
feat: 学習コンテンツ失敗時のsonnerトースト通知を追加

### DIFF
--- a/packages/web/app/features/content/hooks/use-content-creation/use-content-creation.ts
+++ b/packages/web/app/features/content/hooks/use-content-creation/use-content-creation.ts
@@ -27,15 +27,22 @@ export function useContentCreation() {
       // 入力方法に応じてソースを作成
       if (inputMethod === "website") {
         // URLからソースを作成
+        toast.loading("Webサイトからコンテンツを取得中...", { id: "content-creation" });
         response = await createSourceFromUrl({ url: content });
+        toast.success("Webサイトからコンテンツを取得しました", { id: "content-creation" });
       } else {
         // テキストまたはファイルからソースを作成
+        toast.loading("コンテンツを処理中...", { id: "content-creation" });
         response = await createSource({
           content,
           type: "TEXT",
         });
+        toast.success("コンテンツを作成しました", { id: "content-creation" });
       }
 
+      // タイトル生成とフラッシュカード作成
+      toast.loading("タイトルとフラッシュカードを生成中...", { id: "content-creation" });
+      
       // ソースのタイトルを更新
       await postTitle({ sourceId: response.id });
 
@@ -45,9 +52,29 @@ export function useContentCreation() {
       // ソース一覧を更新
       mutate("/api/sources");
 
+      // 成功通知
+      toast.success("学習コンテンツが正常に作成されました！フラッシュカードの学習を開始できます。", { 
+        id: "content-creation",
+        duration: 5000 
+      });
+
       navigate(`/content/${response.id}/flashcards`);
     } catch (error) {
-      toast.error("学習コンテンツの作成に失敗しました");
+      // エラーメッセージをより詳細に
+      let errorMessage = "学習コンテンツの作成に失敗しました";
+      
+      if (error instanceof Error) {
+        if (error.message.includes("URL")) {
+          errorMessage = "URLからコンテンツを取得できませんでした。URLが正しいか確認してください。";
+        } else if (error.message.includes("network")) {
+          errorMessage = "ネットワークエラーが発生しました。インターネット接続を確認してください。";
+        }
+      }
+      
+      toast.error(errorMessage, { 
+        id: "content-creation",
+        duration: 6000 
+      });
       console.error(error);
     } finally {
       setIsLoading(false);

--- a/packages/web/app/features/content/hooks/use-content-creation/use-content-creation.ts
+++ b/packages/web/app/features/content/hooks/use-content-creation/use-content-creation.ts
@@ -27,22 +27,15 @@ export function useContentCreation() {
       // 入力方法に応じてソースを作成
       if (inputMethod === "website") {
         // URLからソースを作成
-        toast.loading("Webサイトからコンテンツを取得中...", { id: "content-creation" });
         response = await createSourceFromUrl({ url: content });
-        toast.success("Webサイトからコンテンツを取得しました", { id: "content-creation" });
       } else {
         // テキストまたはファイルからソースを作成
-        toast.loading("コンテンツを処理中...", { id: "content-creation" });
         response = await createSource({
           content,
           type: "TEXT",
         });
-        toast.success("コンテンツを作成しました", { id: "content-creation" });
       }
 
-      // タイトル生成とフラッシュカード作成
-      toast.loading("タイトルとフラッシュカードを生成中...", { id: "content-creation" });
-      
       // ソースのタイトルを更新
       await postTitle({ sourceId: response.id });
 
@@ -51,12 +44,6 @@ export function useContentCreation() {
 
       // ソース一覧を更新
       mutate("/api/sources");
-
-      // 成功通知
-      toast.success("学習コンテンツが正常に作成されました！フラッシュカードの学習を開始できます。", { 
-        id: "content-creation",
-        duration: 5000 
-      });
 
       navigate(`/content/${response.id}/flashcards`);
     } catch (error) {
@@ -72,7 +59,6 @@ export function useContentCreation() {
       }
       
       toast.error(errorMessage, { 
-        id: "content-creation",
         duration: 6000 
       });
       console.error(error);

--- a/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
+++ b/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { toast } from "sonner";
 import { cn } from "~/lib/utils";
 import { Button } from "~/components/ui/button";
 import { FlashcardItem } from "../flashcard-item";
@@ -52,6 +53,24 @@ export function FlashcardDeck({ flashcards, className }: Props) {
         // 最後のカードの場合は完了状態に移行
         setCurrentIndex(flashcards.length);
         setShowCelebration(true);
+        
+        // 完了トースト通知
+        const okCount = Object.values(completedCards).filter((v) => v === "ok").length + (completedCards[flashcards[currentIndex]?.id] === "ok" ? 0 : 1);
+        const accuracy = Math.round((okCount / flashcards.length) * 100);
+        
+        if (accuracy >= 80) {
+          toast.success(`🎉 素晴らしい！${flashcards.length}枚の学習を完了しました（正解率: ${accuracy}%）`, {
+            duration: 6000,
+          });
+        } else if (accuracy >= 60) {
+          toast.success(`👏 よくできました！${flashcards.length}枚の学習を完了しました（正解率: ${accuracy}%）`, {
+            duration: 6000,
+          });
+        } else {
+          toast.success(`📚 学習完了！もう一度チャレンジしてみましょう（正解率: ${accuracy}%）`, {
+            duration: 6000,
+          });
+        }
       } else {
         // 次のカードに移動
         setCurrentIndex(currentIndex + 1);

--- a/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
+++ b/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { toast } from "sonner";
 import { cn } from "~/lib/utils";
 import { Button } from "~/components/ui/button";
 import { FlashcardItem } from "../flashcard-item";
@@ -53,24 +52,6 @@ export function FlashcardDeck({ flashcards, className }: Props) {
         // 最後のカードの場合は完了状態に移行
         setCurrentIndex(flashcards.length);
         setShowCelebration(true);
-        
-        // 完了トースト通知
-        const okCount = Object.values(completedCards).filter((v) => v === "ok").length + (completedCards[flashcards[currentIndex]?.id] === "ok" ? 0 : 1);
-        const accuracy = Math.round((okCount / flashcards.length) * 100);
-        
-        if (accuracy >= 80) {
-          toast.success(`🎉 素晴らしい！${flashcards.length}枚の学習を完了しました（正解率: ${accuracy}%）`, {
-            duration: 6000,
-          });
-        } else if (accuracy >= 60) {
-          toast.success(`👏 よくできました！${flashcards.length}枚の学習を完了しました（正解率: ${accuracy}%）`, {
-            duration: 6000,
-          });
-        } else {
-          toast.success(`📚 学習完了！もう一度チャレンジしてみましょう（正解率: ${accuracy}%）`, {
-            duration: 6000,
-          });
-        }
       } else {
         // 次のカードに移動
         setCurrentIndex(currentIndex + 1);

--- a/packages/web/app/root.tsx
+++ b/packages/web/app/root.tsx
@@ -9,7 +9,6 @@ import type { LinksFunction } from "@remix-run/node";
 
 import "./tailwind.css";
 import Provider from "./provider";
-import { Toaster } from "./components/ui/toaster";
 
 export const links: LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -46,7 +45,6 @@ export default function App() {
   return (
     <Provider>
       <Outlet />
-      <Toaster />
     </Provider>
   );
 }

--- a/packages/web/app/routes/_content.content.$id_.flashcards.tsx
+++ b/packages/web/app/routes/_content.content.$id_.flashcards.tsx
@@ -31,15 +31,6 @@ export default function ContentFlashcards() {
     }
   }, [error]);
 
-  // フラッシュカードがない場合の通知
-  useEffect(() => {
-    if (data && (!data.flashcards || data.flashcards.length === 0)) {
-      toast.info("このコンテンツにはまだフラッシュカードが作成されていません。", {
-        duration: 4000,
-      });
-    }
-  }, [data]);
-
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">

--- a/packages/web/app/routes/_content.content.$id_.flashcards.tsx
+++ b/packages/web/app/routes/_content.content.$id_.flashcards.tsx
@@ -1,9 +1,11 @@
 import { useParams } from "@remix-run/react";
 import useSWR from "swr";
+import { toast } from "sonner";
 import { getFlashcardsBySourceId } from "~/services/flashcard";
 import { FlashcardDeck } from "~/features/flashcard/components";
 import { Spinner } from "~/components/ui/spinner";
 import { useContentDetail } from "~/features/content";
+import { useEffect } from "react";
 
 export default function ContentFlashcards() {
   const { id } = useParams();
@@ -19,6 +21,24 @@ export default function ContentFlashcards() {
       revalidateOnFocus: false,
     }
   );
+
+  // エラー時のトースト通知
+  useEffect(() => {
+    if (error) {
+      toast.error("フラッシュカードの読み込みに失敗しました。ページを再読み込みしてください。", {
+        duration: 6000,
+      });
+    }
+  }, [error]);
+
+  // フラッシュカードがない場合の通知
+  useEffect(() => {
+    if (data && (!data.flashcards || data.flashcards.length === 0)) {
+      toast.info("このコンテンツにはまだフラッシュカードが作成されていません。", {
+        duration: 4000,
+      });
+    }
+  }, [data]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- 学習コンテンツ作成・読み込み失敗時のみにトースト通知を追加
- エラーの種類に応じてより具体的で分かりやすいメッセージを表示

## Changes

### エラー時の通知のみ
- **コンテンツ作成エラー**: URLエラー、ネットワークエラーなど具体的なエラーメッセージを表示
- **フラッシュカード読み込みエラー**: 読み込み失敗時の通知を追加
- **成功時の通知は削除**: よりシンプルなUXを提供

### 具体的な改善点
- URLから取得失敗時：「URLからコンテンツを取得できませんでした。URLが正しいか確認してください。」
- ネットワークエラー時：「ネットワークエラーが発生しました。インターネット接続を確認してください。」
- フラッシュカード読み込み失敗時：「フラッシュカードの読み込みに失敗しました。ページを再読み込みしてください。」

## Test plan
- [x] URLエラー時のトースト表示を確認
- [x] ネットワークエラー時のトースト表示を確認
- [x] フラッシュカード読み込みエラー時のトースト表示を確認
- [x] build、lint、typecheckが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)