### PR TITLE
fix: フラッシュカード画面遷移時のstateを初期化

### DIFF
--- a/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
+++ b/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
@@ -18,6 +18,14 @@ export function FlashcardDeck({ flashcards, className }: Props) {
   const [isAnimating, setIsAnimating] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
 
+  // flashcardsが変更された時（異なるフラッシュカードに遷移した時）にstateを初期化
+  useEffect(() => {
+    setCurrentIndex(0);
+    setCompletedCards({});
+    setIsAnimating(false);
+    setShowCelebration(false);
+  }, [flashcards]);
+
   function handleSwipeLeft() {
     const currentCard = flashcards[currentIndex];
     if (currentCard) {


### PR DESCRIPTION
## Summary
- フラッシュカード画面遷移時に前の進行度が残っている問題を修正
- `flashcards`プロパティが変更された時にすべてのstateを初期化するuseEffectを追加

## Changes
- `flashcard-deck.tsx`に`useEffect`を追加し、flashcardsが変更された時に以下のstateを初期化:
  - `currentIndex`: 0にリセット
  - `completedCards`: 空オブジェクトにリセット
  - `isAnimating`: falseにリセット
  - `showCelebration`: falseにリセット

## Test plan
- [ ] 異なるフラッシュカードに遷移した時に進行度がリセットされることを確認
- [ ] 新しいフラッシュカードで最初のカードから開始することを確認
- [ ] 完了状態やアニメーション状態がリセットされることを確認

fixes #25

🤖 Generated with [Claude Code](https://claude.ai/code)