### PR TITLE
feat: 学習コンテンツ削除機能を追加

### DIFF
--- a/packages/api/src/routes/sources.ts
+++ b/packages/api/src/routes/sources.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { Context } from "hono";
 import {
   createSource,
+  deleteSource,
   getSourceById,
   getSources,
   updateSource,
@@ -10,6 +11,7 @@ import {
 import { getFlashcardsBySourceId } from "@/services/flashcard";
 import { zValidator } from "@hono/zod-validator";
 import {
+  DeleteSourceResponse,
   GetSourceDetailResponse,
   PostSourceBodySchema,
   PostSourceDetailResponse,
@@ -120,6 +122,27 @@ app
       type: result[0].type,
       createdAt: result[0].createdAt ?? "",
       updatedAt: result[0].updatedAt ?? "",
+    };
+
+    return c.json(response);
+  })
+  .delete("/:id", async (c) => {
+    const id = c.req.param("id");
+    const db = drizzle(c.env.DB);
+
+    const existingSource = await getSourceById(db, id);
+    if (existingSource.length === 0) {
+      return c.json({ message: "Source not found" }, 404);
+    }
+
+    const result = await deleteSource(db, id);
+
+    if (result.length === 0) {
+      return c.json({ message: "Failed to delete source" }, 500);
+    }
+
+    const response: DeleteSourceResponse = {
+      message: "Source deleted successfully",
     };
 
     return c.json(response);

--- a/packages/api/src/services/sources.ts
+++ b/packages/api/src/services/sources.ts
@@ -64,3 +64,7 @@ export const updateSource = async (
     .where(eq(source.id, id))
     .returning();
 };
+
+export const deleteSource = async (db: DrizzleD1Database, id: string) => {
+  return await db.delete(source).where(eq(source.id, id)).returning();
+};

--- a/packages/shared/src/schemas/source.ts
+++ b/packages/shared/src/schemas/source.ts
@@ -199,3 +199,15 @@ export type PostTitleRequestBody = z.infer<typeof postTitleRequestBody>;
  * タイトル生成 (POST) のレスポンスの型
  */
 export type PostTitleResponse = z.infer<typeof postTitleResponseSchema>;
+
+/**
+ * ソース削除 (DELETE) のレスポンススキーマ
+ */
+export const DeleteSourceResponseSchema = z.object({
+  message: z.string(),
+});
+
+/**
+ * ソース削除 (DELETE) のレスポンスの型
+ */
+export type DeleteSourceResponse = z.infer<typeof DeleteSourceResponseSchema>;

--- a/packages/web/app/services/sources.ts
+++ b/packages/web/app/services/sources.ts
@@ -1,4 +1,5 @@
 import {
+  DeleteSourceResponse,
   GetSourceDetailResponse,
   GetSourcesResponse,
   PutSourceBody,
@@ -32,4 +33,8 @@ export const createSourceFromUrl = async (body: PostSourceFromUrlBody) => {
 
 export const createSourceFromPdf = async (body: PostSourceFromPdfBody) => {
   return api.post<PostSourceDetailResponse>("/sources/pdf", body);
+};
+
+export const deleteSource = async (id: string) => {
+  return api.delete<DeleteSourceResponse>(`/sources/${id}`);
 };


### PR DESCRIPTION
## Summary
- 学習コンテンツ（ソース）の削除機能を実装
- 削除時の確認ダイアログと成功/失敗通知を追加
- 削除後のコンテンツ一覧自動更新

## Changes
### Backend (API)
- `packages/api/src/routes/sources.ts`: DELETE /:id エンドポイントを追加
- `packages/api/src/services/sources.ts`: deleteSource関数を追加
- `packages/shared/src/schemas/source.ts`: 削除API用のZodスキーマを追加

### Frontend
- `packages/web/app/services/sources.ts`: deleteSource API呼び出し関数を追加
- `packages/web/app/features/content/components/content-list/content-list.tsx`: 
  - 削除ボタン（ゴミ箱アイコン）を各コンテンツカードに追加
  - 削除確認ダイアログを実装
  - 削除処理とローディング状態管理
  - 成功/失敗時のトースト通知
  - 削除後のSWRキャッシュ更新

## Features
- ✅ コンテンツ一覧画面に削除ボタンを追加
- ✅ 削除前の確認ダイアログ表示
- ✅ 削除中のローディング状態表示
- ✅ 削除成功/失敗時の通知
- ✅ 削除後のコンテンツ一覧自動更新
- ✅ 関連フラッシュカードの自動削除（データベース外部キー制約により）

## Test plan
- [ ] コンテンツ一覧でゴミ箱アイコンが表示されることを確認
- [ ] 削除ボタンクリックで確認ダイアログが表示されることを確認
- [ ] キャンセルボタンで削除がキャンセルされることを確認
- [ ] 削除実行でコンテンツが削除されることを確認
- [ ] 削除後にコンテンツ一覧が更新されることを確認
- [ ] 削除時に関連フラッシュカードも削除されることを確認
- [ ] 削除中はボタンがローディング状態になることを確認
- [ ] 削除成功/失敗時に適切な通知が表示されることを確認

fixes #22

🤖 Generated with [Claude Code](https://claude.ai/code)