### PR TITLE
fix: フラッシュカードのカスケード削除を追加

### DIFF
--- a/packages/api/migrations/0003_blushing_toxin.sql
+++ b/packages/api/migrations/0003_blushing_toxin.sql
@@ -1,0 +1,15 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_flashcard` (
+	`id` text PRIMARY KEY NOT NULL,
+	`source_id` text,
+	`question` text NOT NULL,
+	`answer` text NOT NULL,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP,
+	FOREIGN KEY (`source_id`) REFERENCES `source`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_flashcard`("id", "source_id", "question", "answer", "created_at", "updated_at") SELECT "id", "source_id", "question", "answer", "created_at", "updated_at" FROM `flashcard`;--> statement-breakpoint
+DROP TABLE `flashcard`;--> statement-breakpoint
+ALTER TABLE `__new_flashcard` RENAME TO `flashcard`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/packages/api/migrations/meta/0003_snapshot.json
+++ b/packages/api/migrations/meta/0003_snapshot.json
@@ -1,0 +1,303 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5fa28ec9-e94d-4385-b6e5-06215d3054f1",
+  "prevId": "2b7377b0-b9ef-43b1-8b66-6c640ec652f8",
+  "tables": {
+    "explain_history": {
+      "name": "explain_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expression": {
+          "name": "expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "explain_history_uid_users_uid_fk": {
+          "name": "explain_history_uid_users_uid_fk",
+          "tableFrom": "explain_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uid"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "flashcard": {
+      "name": "flashcard",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "flashcard_source_id_source_id_fk": {
+          "name": "flashcard_source_id_source_id_fk",
+          "tableFrom": "flashcard",
+          "tableTo": "source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_DATE"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_DATE"
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subscription_plan": {
+          "name": "subscription_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_expires_at": {
+          "name": "subscription_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source": {
+      "name": "source",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_uid_users_uid_fk": {
+          "name": "source_uid_users_uid_fk",
+          "tableFrom": "source",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uid"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1748684212997,
       "tag": "0002_vengeful_red_wolf",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1749979350887,
+      "tag": "0003_blushing_toxin",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schemas/flashcard.ts
+++ b/packages/api/src/db/schemas/flashcard.ts
@@ -6,7 +6,7 @@ export const flashcard = sqliteTable(
   "flashcard",
   {
     id: text("id").primaryKey(),
-    sourceId: text("source_id").references(() => source.id),
+    sourceId: text("source_id").references(() => source.id, { onDelete: 'cascade' }),
     question: text("question").notNull(),
     answer: text("answer").notNull(),
     createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`),


### PR DESCRIPTION
## Summary
- ソース削除時に関連するフラッシュカードも自動削除されるようカスケード削除を追加
- データベース外部キー制約に `ON DELETE cascade` を設定

## Problem
現在の実装では、学習コンテンツ（ソース）を削除してもフラッシュカードが残り、孤立データが発生する問題がありました。

## Solution
- `packages/api/src/db/schemas/flashcard.ts` の外部キー制約に `onDelete: 'cascade'` を追加
- データベースマイグレーション `0003_blushing_toxin.sql` を生成
- 本番データベースにマイグレーション適用済み

## Changes
- `flashcard.sourceId` 外部キー制約を `FOREIGN KEY (source_id) REFERENCES source(id) ON DELETE cascade` に変更
- これにより、ソース削除時に関連フラッシュカードも自動削除

## Test plan
- [ ] ソースを削除した時に関連フラッシュカードも削除されることを確認
- [ ] 孤立したフラッシュカードが残らないことを確認

## Note
本番データベースにはマイグレーション適用済みです。

🤖 Generated with [Claude Code](https://claude.ai/code)