### PR TITLE
fix: 削除成功時にエラートーストが表示される問題を修正

### DIFF
--- a/packages/web/app/features/content/components/content-list/content-list.tsx
+++ b/packages/web/app/features/content/components/content-list/content-list.tsx
@@ -29,7 +29,7 @@ export function ContentList({ contents, isLoading = false }: ContentListProps) {
     setDeletingId(id);
     try {
       await deleteSource(id);
-      await mutate("/sources");
+      await mutate("/api/sources");
       toast.success(`「${title || "無題"}」を削除しました`);
     } catch (error) {
       console.error("Delete error:", error);

--- a/packages/web/app/services/base.ts
+++ b/packages/web/app/services/base.ts
@@ -70,8 +70,13 @@ async function baseFetch<T>(
   });
 
   if (!response.ok) {
-    const message = (await response.json()).message || response.statusText;
-    throw new Error(message);
+    try {
+      const errorData = await response.json();
+      const message = errorData.message || response.statusText;
+      throw new Error(message);
+    } catch (parseError) {
+      throw new Error(response.statusText || 'Request failed');
+    }
   }
 
   return response.json();


### PR DESCRIPTION
## Summary
削除機能において、実際には削除が成功しているにも関わらず「削除に失敗しました」のトーストが表示される問題を修正。

## Problem
- 学習コンテンツの削除は実際には成功している
- しかし、フロントエンドで「削除に失敗しました」のエラートーストが表示される
- ユーザー体験の悪化とUXの問題

## Root Cause
**SWRキャッシュキー不一致**が主な原因：
- SWRのキャッシュキー: `/api/sources` (contents.tsx)  
- mutateで指定しているキー: `/sources` (content-list.tsx)
- キャッシュが更新されず、後続処理でエラーが発生

## Solution
### 1. SWRキャッシュキー不一致の修正
- `mutate("/sources")` → `mutate("/api/sources")` に変更
- SWRのキャッシュキーと一致させることで適切なキャッシュ更新を実現

### 2. APIエラーハンドリングの堅牢性向上
- JSON解析エラー時の適切なエラーハンドリングを追加
- 非JSONレスポンス時でも適切にエラーメッセージを表示

## Changes
### `packages/web/app/features/content/components/content-list/content-list.tsx`
```diff
- await mutate("/sources");
+ await mutate("/api/sources");
```

### `packages/web/app/services/base.ts`
```diff
  if (\!response.ok) {
-   const message = (await response.json()).message || response.statusText;
-   throw new Error(message);
+   try {
+     const errorData = await response.json();
+     const message = errorData.message || response.statusText;
+     throw new Error(message);
+   } catch (parseError) {
+     throw new Error(response.statusText || 'Request failed');
+   }
  }
```

## Test plan
- [ ] コンテンツを削除した時に「削除しました」の成功トーストが表示されることを確認
- [ ] 削除後にコンテンツ一覧が正しく更新されることを確認
- [ ] 実際に削除に失敗した場合にエラートーストが表示されることを確認
- [ ] ネットワークエラー等の場合に適切なエラーメッセージが表示されることを確認

## Impact
- ✅ 削除成功時に適切な成功トーストが表示される
- ✅ SWRキャッシュが正しく更新される
- ✅ エラーハンドリングがより堅牢になる
- ✅ ユーザー体験の改善

fixes #30

🤖 Generated with [Claude Code](https://claude.ai/code)