### PR TITLE
feat: 項目の表示順を降順（新しい順）に変更

### DIFF
--- a/packages/api/src/services/flashcard.ts
+++ b/packages/api/src/services/flashcard.ts
@@ -1,6 +1,6 @@
 import { DrizzleD1Database } from "drizzle-orm/d1";
 import { source, flashcard } from "@/db/schemas";
-import { eq } from "drizzle-orm";
+import { eq, desc } from "drizzle-orm";
 import { callAnthropic } from "../utils/llm";
 import { Flashcard } from "@toi/shared/src/schemas/source";
 
@@ -83,5 +83,6 @@ export const getFlashcardsBySourceId = async (
   return await db
     .select()
     .from(flashcard)
-    .where(eq(flashcard.sourceId, sourceId));
+    .where(eq(flashcard.sourceId, sourceId))
+    .orderBy(desc(flashcard.createdAt));
 };

--- a/packages/api/src/services/sources.ts
+++ b/packages/api/src/services/sources.ts
@@ -1,10 +1,10 @@
 import { DrizzleD1Database, drizzle } from "drizzle-orm/d1";
 import { source } from "@/db/schemas";
 import { PostSourceBody, PutSourceBody } from "@toi/shared/src/schemas/source";
-import { eq } from "drizzle-orm";
+import { eq, desc } from "drizzle-orm";
 
 export const getSources = async (db: DrizzleD1Database) => {
-  return await db.select().from(source);
+  return await db.select().from(source).orderBy(desc(source.createdAt));
 };
 
 export const getSourceById = async (db: DrizzleD1Database, id: string) => {


### PR DESCRIPTION
## Summary
学習コンテンツ一覧とフラッシュカード一覧の表示順を、作成日時の降順（新しい順）に変更しました。

## Problem
現在、コンテンツとフラッシュカードが作成順（昇順）で表示されており、最新のアイテムを見つけにくい状況でした。

## Solution
データベースクエリに`orderBy(desc(createdAt))`を追加し、最新のアイテムが上位に表示されるよう修正しました。

## Changes
### 1. 学習コンテンツ一覧の降順表示
**File**: `packages/api/src/services/sources.ts`
```diff
export const getSources = async (db: DrizzleD1Database) => {
-  return await db.select().from(source);
+  return await db.select().from(source).orderBy(desc(source.createdAt));
};
```

### 2. フラッシュカード一覧の降順表示
**File**: `packages/api/src/services/flashcard.ts`
```diff
export const getFlashcardsBySourceId = async (
  db: DrizzleD1Database,
  sourceId: string
) => {
  return await db
    .select()
    .from(flashcard)
    .where(eq(flashcard.sourceId, sourceId))
+    .orderBy(desc(flashcard.createdAt));
};
```

## Impact
- ✅ **学習コンテンツ一覧**: 最新作成のコンテンツが上位に表示
- ✅ **フラッシュカード一覧**: 最新作成のフラッシュカードが上位に表示
- ✅ **ユーザー体験向上**: 最近追加したアイテムをすぐに見つけられる
- ✅ **一貫性**: すべてのリスト表示で統一された表示順

## Test plan
- [ ] コンテンツ一覧で最新作成のコンテンツが上位に表示されることを確認
- [ ] フラッシュカード学習画面で最新作成のカードが最初に表示されることを確認
- [ ] 新しいコンテンツを作成した時に一覧の最上位に表示されることを確認
- [ ] 既存のフラッシュカードがある状態で新しいカードを生成し、最上位に表示されることを確認

## Note
フロントエンド側の変更は不要です。APIの変更により、自動的に新しい表示順が適用されます。

fixes #27

🤖 Generated with [Claude Code](https://claude.ai/code)