### PR TITLE
fix: フラッシュカード学習機能のバグを修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,34 @@ npm run test:api:coverage    # Run API tests with coverage
 
 ## Development Workflow
 
+### Issue対応フロー
+**IMPORTANT**: Issue対応時は必ず以下の手順に従うこと：
+
+1. **mainブランチから新しい作業ブランチを作成**
+   ```bash
+   git checkout main
+   git pull origin main
+   git checkout -b fix/issue-description  # バグ修正の場合
+   git checkout -b feat/issue-description # 新機能の場合
+   ```
+
+2. **Issue対応を実装**
+   - バグ修正、新機能実装、改善などを行う
+   - コードの品質を保つため lint と typecheck を実行
+
+3. **変更をコミット**
+   - 適切なコミットメッセージで変更をコミット
+   - 必要に応じて複数のコミットに分割
+
+4. **PRを作成**
+   ```bash
+   git push origin branch-name
+   gh pr create --title "PR title" --body "PR description"
+   ```
+
+5. **レビュー後にマージ**
+   - PRがレビュー・承認されたらmainブランチにマージ
+
 ### API Development
 1. Define schemas in `/packages/shared/src/schemas/`
 2. Create route in `/packages/api/src/routes/`

--- a/packages/web/app/features/flashcard/components/learning-settings-dialog/learning-settings-dialog.tsx
+++ b/packages/web/app/features/flashcard/components/learning-settings-dialog/learning-settings-dialog.tsx
@@ -12,7 +12,10 @@ export function LearningSettingsDialog() {
     <div className="space-y-6 py-4">
       {/* Shuffle Setting */}
       <div className="space-y-2">
-        <div className="flex items-center space-x-3">
+        <Label 
+          htmlFor="shuffle-dialog" 
+          className="flex items-center space-x-3 cursor-pointer hover:bg-gray-50 p-2 rounded-md transition-colors"
+        >
           <Checkbox
             id="shuffle-dialog"
             checked={shuffle}
@@ -20,19 +23,22 @@ export function LearningSettingsDialog() {
           />
           <div className="flex items-center space-x-2">
             <Shuffle className="h-4 w-4 text-gray-500" />
-            <Label htmlFor="shuffle-dialog" className="text-sm font-medium cursor-pointer">
+            <span className="text-sm font-medium">
               シャッフル
-            </Label>
+            </span>
           </div>
-        </div>
-        <p className="text-xs text-gray-500 ml-7">
+        </Label>
+        <p className="text-xs text-gray-500 ml-9">
           カードの表示順をランダムにします
         </p>
       </div>
 
       {/* Thorough Learning Setting */}
       <div className="space-y-2">
-        <div className="flex items-center space-x-3">
+        <Label 
+          htmlFor="thorough-learning-dialog" 
+          className="flex items-center space-x-3 cursor-pointer hover:bg-gray-50 p-2 rounded-md transition-colors"
+        >
           <Checkbox
             id="thorough-learning-dialog"
             checked={thoroughLearning}
@@ -40,12 +46,12 @@ export function LearningSettingsDialog() {
           />
           <div className="flex items-center space-x-2">
             <RotateCcw className="h-4 w-4 text-gray-500" />
-            <Label htmlFor="thorough-learning-dialog" className="text-sm font-medium cursor-pointer">
+            <span className="text-sm font-medium">
               徹底学習
-            </Label>
+            </span>
           </div>
-        </div>
-        <p className="text-xs text-gray-500 ml-7">
+        </Label>
+        <p className="text-xs text-gray-500 ml-9">
           「NG」のカードを「OK」になるまで繰り返します
         </p>
       </div>


### PR DESCRIPTION
## Summary
フラッシュカード学習機能に発生していた以下のバグを修正しました：

- シャッフル機能をオンにすると表示が無限に切り替わる問題
- OK/NGボタンで次のカードに切り替わらない問題  
- 学習設定ダイアログ内のチェックボックスが押しにくい問題

## Changes
- `useMemo`から`useCallback`への変更によりシャッフル機能の無限ループを解決
- デッキ生成とシャッフル処理の分離により状態管理を最適化
- チェックボックスのクリック可能範囲を拡大し、ホバーエフェクトを追加
- Issue対応フローをCLAUDE.mdに追加

## Test plan
- [x] シャッフル機能のオン/オフが正常に動作することを確認
- [x] OK/NGボタンでカードが正常に切り替わることを確認
- [x] 学習設定ダイアログの操作性が向上していることを確認
- [x] TypeScriptとESLintのチェックが通ることを確認

Closes #34

🤖 Generated with [Claude Code](https://claude.ai/code)