### PR TITLE
fix: 徹底学習モードでNGカードが表示されない問題と進捗バー表示を修正

### DIFF
--- a/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
+++ b/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
@@ -53,7 +53,12 @@ export function FlashcardDeck({ flashcards, className }: Props) {
     const newDeck = createDeck();
     setCurrentDeck(newDeck);
     setIsShuffled(false); // Reset shuffle status when deck changes
-  }, [createDeck]);
+    
+    // If we're switching to NG cards review and currentIndex is at the end, reset it
+    if (thoroughLearning && ngCards.length > 0 && currentIndex >= currentDeck.length) {
+      setCurrentIndex(0);
+    }
+  }, [createDeck, thoroughLearning, ngCards.length, currentIndex, currentDeck.length]);
 
   // Handle shuffle setting changes
   useEffect(() => {
@@ -123,9 +128,9 @@ export function FlashcardDeck({ flashcards, className }: Props) {
       if (isLastCard) {
         // If thorough learning is enabled and there are NG cards to review
         if (thoroughLearning && ngCards.length > 0) {
-          // Reset to start reviewing NG cards
-          setCurrentIndex(0);
-          // Deck will be updated automatically by createDeck memo
+          // Wait for the deck to be updated before resetting index
+          // This will be handled by the useEffect that watches ngCards changes
+          setCurrentIndex(currentDeck.length); // Temporarily move to end
         } else {
           // Complete the learning session
           setCurrentIndex(currentDeck.length);
@@ -241,23 +246,25 @@ export function FlashcardDeck({ flashcards, className }: Props) {
 
   return (
     <div className={cn("flex flex-col items-center space-y-6", className)}>
-      {/* Progress */}
-      <div className="w-full max-w-md">
-        <div className="flex justify-between text-sm text-gray-600 mb-2">
-          <span>
-            {currentIndex + 1} / {currentDeck.length}
-          </span>
-          <span>{progressPercentage}%</span>
+      {/* Progress - Hide progress bar in thorough learning mode */}
+      {!thoroughLearning && (
+        <div className="w-full max-w-md">
+          <div className="flex justify-between text-sm text-gray-600 mb-2">
+            <span>
+              {currentIndex + 1} / {currentDeck.length}
+            </span>
+            <span>{progressPercentage}%</span>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-2">
+            <div
+              className="bg-blue-500 h-2 rounded-full transition-all duration-300"
+              style={{
+                width: `${progressPercentage}%`,
+              }}
+            />
+          </div>
         </div>
-        <div className="w-full bg-gray-200 rounded-full h-2">
-          <div
-            className="bg-blue-500 h-2 rounded-full transition-all duration-300"
-            style={{
-              width: `${progressPercentage}%`,
-            }}
-          />
-        </div>
-      </div>
+      )}
 
       {/* Card Stack */}
       <div className="relative">


### PR DESCRIPTION
## Summary
- 徹底学習モードでNGカードが表示されない問題を修正
- 徹底学習モードでは進捗バーを非表示に変更

## 修正内容
- デッキ更新のタイミング問題を解決し、NGカードレビュー開始時の適切なインデックス制御を実装
- 徹底学習モード時は進捗バーを非表示にして、通常の学習と区別

## Test plan
- [ ] 徹底学習モードを有効にしてフラッシュカード学習を開始
- [ ] カードをNGにした後、最後のカードまで進む
- [ ] NGカードのレビューが正常に開始されることを確認
- [ ] 徹底学習モード時に進捗バーが表示されないことを確認

Fixes #38

🤖 Generated with [Claude Code](https://claude.ai/code)