### PR TITLE
fix: シャッフル時の進捗バー計算と完了画面の表示数値を修正

### DIFF
--- a/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
+++ b/packages/web/app/features/flashcard/components/flashcard-deck/flashcard-deck.tsx
@@ -185,7 +185,7 @@ export function FlashcardDeck({ flashcards, className }: Props) {
   // 進捗率の計算（完了時は100%）
   const progressPercentage = isCompleted
     ? 100
-    : Math.round((completedCount / flashcards.length) * 100);
+    : Math.round((completedCount / currentDeck.length) * 100);
 
   if (isCompleted) {
     return (
@@ -198,7 +198,7 @@ export function FlashcardDeck({ flashcards, className }: Props) {
         <div className="w-full max-w-md">
           <div className="flex justify-between text-sm text-gray-600 mb-2">
             <span>
-              {flashcards.length} / {flashcards.length}
+              {currentDeck.length} / {currentDeck.length}
             </span>
             <span className="text-green-600 font-bold">100%</span>
           </div>
@@ -215,7 +215,7 @@ export function FlashcardDeck({ flashcards, className }: Props) {
           <h2 className="text-2xl font-bold text-gray-800">学習完了!</h2>
           <div className="space-y-2">
             <p className="text-lg text-gray-600">
-              {flashcards.length}枚中{completedCount}枚完了
+              {currentDeck.length}枚中{completedCount}枚完了
             </p>
             <div className="flex justify-center space-x-6">
               <div className="text-center">


### PR DESCRIPTION
## Summary
- シャッフル時の進捗バー計算を修正
- 完了画面の表示数値を修正

## 修正内容
- 進捗バーの計算で`flashcards.length`ではなく`currentDeck.length`を使用するよう修正
- 完了画面の表示も`currentDeck.length`ベースに変更
- これによりシャッフル時に進捗バーが100%になるように改善
- 正解・不正解の合計枚数が元のカード枚数と一致するよう修正

## Test plan
- [ ] シャッフル機能を有効にしてフラッシュカード学習を開始
- [ ] 全てのカードをめくって進捗バーが100%になることを確認
- [ ] 完了画面で正解・不正解の合計枚数が元のカード枚数と一致することを確認
- [ ] 通常モード（シャッフルなし）でも正常に動作することを確認

Fixes #40

🤖 Generated with [Claude Code](https://claude.ai/code)