### PR TITLE
fix: 通常モードでNGカード削除とプログレス計算を修正

### DIFF
--- a/packages/web/app/features/flashcard/hooks/use-flashcard-deck/use-flashcard-deck.ts
+++ b/packages/web/app/features/flashcard/hooks/use-flashcard-deck/use-flashcard-deck.ts
@@ -101,7 +101,7 @@ export function useFlashcardDeck({
     }
   }, [currentDeck, thoroughLearning]);
 
-  // Handle NG - move card to end of deck
+  // Handle NG - behavior depends on learning mode
   const handleNg = useCallback(() => {
     const currentCard = currentDeck[0]; // Always use index 0
     if (!currentCard) return;
@@ -115,14 +115,19 @@ export function useFlashcardDeck({
       }
     }));
 
-    // Move card to end of deck
-    setCurrentDeck(prev => {
-      const newDeck = [...prev];
-      const [movedCard] = newDeck.splice(0, 1);
-      newDeck.push(movedCard);
-      return newDeck;
-    });
-  }, [currentDeck]);
+    if (thoroughLearning) {
+      // In thorough learning mode, move card to end of deck
+      setCurrentDeck(prev => {
+        const newDeck = [...prev];
+        const [movedCard] = newDeck.splice(0, 1);
+        newDeck.push(movedCard);
+        return newDeck;
+      });
+    } else {
+      // In normal mode, remove card from deck (same as OK)
+      setCurrentDeck(prev => prev.slice(1));
+    }
+  }, [currentDeck, thoroughLearning]);
 
   // Reset function
   const reset = useCallback(() => {
@@ -139,10 +144,12 @@ export function useFlashcardDeck({
   // Calculate current card (always index 0)
   const currentCard = currentDeck[0];
 
-  // Calculate total OK cards
-  const totalOkCards = removedCardIds.size;
+  // Calculate total OK cards and progress
+  const totalOkCards = thoroughLearning 
+    ? removedCardIds.size  // In thorough learning, count removed cards
+    : totalOriginalCards - currentDeck.length;  // In normal mode, count processed cards
 
-  // Calculate progress - based on OK cards out of total
+  // Calculate progress - based on processed cards out of total
   const progressPercentage = Math.round((totalOkCards / totalOriginalCards) * 100);
 
   return {


### PR DESCRIPTION
## Summary
- 通常モード（徹底学習オフ）でNGカードを末尾移動ではなく削除に変更
- 通常モードでの進捗バー計算を修正（0%のまま固定される問題を解決）
- 徹底学習モードではNGカードの末尾移動動作を維持

## Changes
### useFlashcardDeck Hook
- `handleNg`関数で学習モードに応じた動作分岐を追加
- 通常モード: NGカードを削除（`prev.slice(1)`）
- 徹底学習モード: NGカードを末尾移動（`splice + push`）
- 進捗計算ロジックを修正: 通常モードでは`totalOriginalCards - currentDeck.length`で処理済みカード数を計算

### Tests
- 通常モードでのNG動作テストを追加・修正
- 進捗計算の正確性を検証するテストを追加
- 徹底学習モードのテストと明確に分離

## Test plan
- [x] 全テストが通過（182 passed | 2 skipped）
- [x] lint・typecheck エラーなし
- [x] 通常モードでNGボタンを押すとカードが削除されることを確認
- [x] 通常モードで進捗バーが正しく更新されることを確認
- [x] 徹底学習モードでNGボタンを押すとカードが末尾に移動することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)