### PR TITLE
fix: フラッシュカード画面のモバイル表示レイアウトを改善

### DIFF
--- a/packages/web/app/components/layout/mobile-header/mobile-header.tsx
+++ b/packages/web/app/components/layout/mobile-header/mobile-header.tsx
@@ -21,9 +21,9 @@ function MobileHeader({ className, onMenuClick, ...props }: MobileHeaderProps) {
         variant="outline"
         size="icon"
         onClick={onMenuClick}
-        className="p-2 size-12 bg-card/30 backdrop-blur-md"
+        className="p-1.5 size-10 bg-card/30 backdrop-blur-md"
       >
-        <Menu className="w-full" />
+        <Menu className="w-5 h-5" />
       </Button>
     </header>
   );

--- a/packages/web/app/features/flashcard/components/flashcard-header/flashcard-header.tsx
+++ b/packages/web/app/features/flashcard/components/flashcard-header/flashcard-header.tsx
@@ -13,17 +13,19 @@ export function FlashcardHeader({ title }: FlashcardHeaderProps) {
 
   return (
     <div className="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold text-gray-800 truncate">
+      <div className="flex items-center justify-center relative md:justify-between">
+        {/* Title - centered on mobile, left-aligned on desktop with proper truncation */}
+        <h1 className="text-xl font-bold text-gray-800 truncate text-center md:text-left max-w-[calc(100%-4rem)] md:max-w-none">
           {title}
         </h1>
         
+        {/* Settings icon - fixed at top right */}
         <Dialog open={isSettingsOpen} onOpenChange={setIsSettingsOpen}>
           <DialogTrigger asChild>
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 w-8 p-0"
+              className="h-8 w-8 p-0 absolute right-0 top-1/2 transform -translate-y-1/2 md:relative md:right-auto md:top-auto md:transform-none"
               aria-label="学習設定"
             >
               <Settings className="h-4 w-4" />


### PR DESCRIPTION
## Summary
Issue #52 のモバイル表示改善要求に対応

## Changes
### FlashcardHeader モバイル最適化
**タイトル表示**
- ✅ モバイル時に中央水平固定配置
- ✅ 適切な省略表示（`max-w-[calc(100%-4rem)]`）
- ✅ デスクトップでは従来の左配置を維持

**設定アイコン**  
- ✅ 右上に固定配置（`absolute right-0`）
- ✅ 同一デザインを維持
- ✅ レスポンシブ対応

### MobileHeader ハンバーガーメニュー縮小
**サイズ調整**
- `size-12` → `size-10` （20% 縮小）
- `w-full` → `w-5 h-5` （アイコンサイズ調整）
- より控えめなサイズで操作性を向上

## Technical Implementation

### Responsive Layout Strategy
```tsx
// Mobile: Center title with fixed right settings
<div className="flex items-center justify-center relative md:justify-between">
  <h1 className="... text-center md:text-left max-w-[calc(100%-4rem)] md:max-w-none">
  <Button className="... absolute right-0 ... md:relative md:right-auto ...">
```

### Mobile-First Design
- モバイル: `justify-center` + absolute positioning
- デスクトップ: `justify-between` の従来レイアウト  
- Tailwind の `md:` プレフィックスで分離

## UI/UX Improvements
1. **視認性向上**: タイトルが中央配置で読みやすく
2. **操作性向上**: より小さなハンバーガーメニュー
3. **一貫性**: 設定アイコンが常に右上固定
4. **レスポンシブ**: デスクトップ表示に影響なし

## Test plan
- [x] lint・typecheck エラーなし
- [x] モバイル表示でタイトル中央配置を確認
- [x] 設定アイコンが右上固定されることを確認  
- [x] ハンバーガーメニューサイズ縮小を確認
- [x] デスクトップ表示が従来通り動作することを確認

## Before/After
### Before
- タイトル: 左寄せ、設定ボタンとのバランスが悪い
- ハンバーガーメニュー: 大きすぎて画面を占有
- 設定ボタン: 相対配置で不安定

### After  
- タイトル: 中央配置、見やすく美しい
- ハンバーガーメニュー: 適切なサイズ
- 設定ボタン: 右上固定で一貫性

🤖 Generated with [Claude Code](https://claude.ai/code)