### PR TITLE
feat: フラッシュカード一括編集機能を実装

### DIFF
--- a/packages/api/src/routes/sources/[id]/flashcards/bulk.ts
+++ b/packages/api/src/routes/sources/[id]/flashcards/bulk.ts
@@ -1,0 +1,42 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { putFlashcardsBulkRequestBodySchema, putFlashcardsBulkResponseSchema } from "@toi/shared/src/schemas/source";
+import { updateFlashcardsBulk } from "@/services/flashcard";
+
+const app = new Hono<{
+  Bindings: {
+    DB: D1Database;
+  };
+}>();
+
+app.put(
+  "/",
+  zValidator("json", putFlashcardsBulkRequestBodySchema),
+  async (c) => {
+    try {
+      const { flashcards } = c.req.valid("json");
+      const sourceId = c.req.param("id");
+
+      const updatedFlashcards = await updateFlashcardsBulk(
+        c.env.DB,
+        sourceId,
+        flashcards
+      );
+
+      const response = putFlashcardsBulkResponseSchema.parse({
+        updatedCount: updatedFlashcards.length,
+        flashcards: updatedFlashcards,
+      });
+
+      return c.json(response);
+    } catch (error) {
+      console.error("Failed to update flashcards in bulk:", error);
+      return c.json(
+        { error: "Failed to update flashcards" },
+        500
+      );
+    }
+  }
+);
+
+export default app;

--- a/packages/api/src/routes/sources/[id]/index.ts
+++ b/packages/api/src/routes/sources/[id]/index.ts
@@ -1,10 +1,12 @@
 import { Hono } from "hono";
 import flashcards from "./flashcards";
 import flashcardId from "./flashcards/[flashcardId]";
+import flashcardsBulk from "./flashcards/bulk";
 
 const app = new Hono();
 
 app.route("/flashcards", flashcards);
 app.route("/flashcards/:flashcardId", flashcardId);
+app.route("/flashcards/bulk", flashcardsBulk);
 
 export default app;

--- a/packages/api/src/services/flashcard.ts
+++ b/packages/api/src/services/flashcard.ts
@@ -112,3 +112,33 @@ export const updateFlashcard = async (
 
   return updatedFlashcard;
 };
+
+/**
+ * フラッシュカードを一括更新する
+ */
+export const updateFlashcardsBulk = async (
+  db: DrizzleD1Database,
+  sourceId: string,
+  flashcards: Array<{ id: string; question: string; answer: string }>
+) => {
+  const updatedFlashcards = [];
+  const now = new Date().toISOString();
+
+  for (const card of flashcards) {
+    const [updatedFlashcard] = await db
+      .update(flashcard)
+      .set({
+        question: card.question,
+        answer: card.answer,
+        updatedAt: now,
+      })
+      .where(eq(flashcard.id, card.id))
+      .returning();
+
+    if (updatedFlashcard) {
+      updatedFlashcards.push(updatedFlashcard);
+    }
+  }
+
+  return updatedFlashcards;
+};

--- a/packages/shared/src/schemas/source.ts
+++ b/packages/shared/src/schemas/source.ts
@@ -241,3 +241,43 @@ export const DeleteSourceResponseSchema = z.object({
  * ソース削除 (DELETE) のレスポンスの型
  */
 export type DeleteSourceResponse = z.infer<typeof DeleteSourceResponseSchema>;
+
+/**
+ * フラッシュカード一括更新 (PUT) のリクエストボディスキーマ
+ */
+export const putFlashcardsBulkRequestBodySchema = z.object({
+  flashcards: z.array(
+    z.object({
+      id: z.string(),
+      question: z.string(),
+      answer: z.string(),
+    })
+  ),
+});
+
+/**
+ * フラッシュカード一括更新 (PUT) のレスポンススキーマ
+ */
+export const putFlashcardsBulkResponseSchema = z.object({
+  updatedCount: z.number(),
+  flashcards: z.array(
+    z.object({
+      id: z.string(),
+      sourceId: z.string(),
+      question: z.string(),
+      answer: z.string(),
+      createdAt: z.string(),
+      updatedAt: z.string(),
+    })
+  ),
+});
+
+/**
+ * フラッシュカード一括更新 (PUT) のリクエストボディの型
+ */
+export type PutFlashcardsBulkRequestBody = z.infer<typeof putFlashcardsBulkRequestBodySchema>;
+
+/**
+ * フラッシュカード一括更新 (PUT) のレスポンスの型
+ */
+export type PutFlashcardsBulkResponse = z.infer<typeof putFlashcardsBulkResponseSchema>;

--- a/packages/web/app/features/flashcard/components/flashcard-bulk-edit/flashcard-bulk-edit.tsx
+++ b/packages/web/app/features/flashcard/components/flashcard-bulk-edit/flashcard-bulk-edit.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Loader2, Save, Trash2 } from "lucide-react";
+import { updateFlashcardsBulk } from "~/services/flashcard";
+import { toast } from "sonner";
+
+export type FlashcardBulkEditData = {
+  id: string;
+  question: string;
+  answer: string;
+};
+
+type FlashcardBulkEditProps = {
+  sourceId: string;
+  flashcards: FlashcardBulkEditData[];
+  onUpdate: () => void;
+};
+
+export function FlashcardBulkEdit({ sourceId, flashcards, onUpdate }: FlashcardBulkEditProps) {
+  const [editedFlashcards, setEditedFlashcards] = useState<FlashcardBulkEditData[]>(flashcards);
+  const [isSaving, setIsSaving] = useState(false);
+  const [deletedIds, setDeletedIds] = useState<Set<string>>(new Set());
+
+  const handleFlashcardChange = (id: string, field: 'question' | 'answer', value: string) => {
+    setEditedFlashcards(prev => 
+      prev.map(card => 
+        card.id === id ? { ...card, [field]: value } : card
+      )
+    );
+  };
+
+  const handleDelete = (id: string) => {
+    setDeletedIds(prev => new Set(prev).add(id));
+  };
+
+  const handleRestore = (id: string) => {
+    setDeletedIds(prev => {
+      const newSet = new Set(prev);
+      newSet.delete(id);
+      return newSet;
+    });
+  };
+
+  const handleSaveAll = async () => {
+    setIsSaving(true);
+    
+    try {
+      const cardsToUpdate = editedFlashcards
+        .filter(card => !deletedIds.has(card.id))
+        .filter(card => {
+          const original = flashcards.find(f => f.id === card.id);
+          return original && (original.question !== card.question || original.answer !== card.answer);
+        });
+
+      if (cardsToUpdate.length === 0) {
+        toast.info('更新する項目がありません');
+        return;
+      }
+
+      await updateFlashcardsBulk(sourceId, {
+        flashcards: cardsToUpdate,
+      });
+      
+      onUpdate();
+      toast.success(`${cardsToUpdate.length}件のフラッシュカードを更新しました`);
+    } catch (error) {
+      console.error('Failed to update flashcards:', error);
+      toast.error('フラッシュカードの更新に失敗しました');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const hasChanges = () => {
+    if (deletedIds.size > 0) return true;
+    
+    return editedFlashcards.some(card => {
+      const original = flashcards.find(f => f.id === card.id);
+      return original && (original.question !== card.question || original.answer !== card.answer);
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">フラッシュカード一括編集</h1>
+          <p className="text-muted-foreground">
+            {flashcards.length}件のフラッシュカードを編集できます
+          </p>
+        </div>
+        <Button 
+          onClick={handleSaveAll}
+          disabled={!hasChanges() || isSaving}
+          size="lg"
+        >
+          {isSaving ? (
+            <>
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              保存中...
+            </>
+          ) : (
+            <>
+              <Save className="w-4 h-4 mr-2" />
+              すべて保存
+            </>
+          )}
+        </Button>
+      </div>
+
+      <div className="grid gap-4">
+        {editedFlashcards.map((card, index) => {
+          const isDeleted = deletedIds.has(card.id);
+          return (
+            <Card 
+              key={card.id} 
+              className={`transition-opacity ${isDeleted ? 'opacity-50' : ''}`}
+            >
+              <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-lg">
+                    フラッシュカード {index + 1}
+                  </CardTitle>
+                  <div className="flex gap-2">
+                    {isDeleted ? (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleRestore(card.id)}
+                      >
+                        復元
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleDelete(card.id)}
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor={`question-${card.id}`}>質問</Label>
+                  <Input
+                    id={`question-${card.id}`}
+                    value={card.question}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleFlashcardChange(card.id, 'question', e.target.value)}
+                    disabled={isDeleted}
+                    placeholder="質問を入力してください"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`answer-${card.id}`}>回答</Label>
+                  <Input
+                    id={`answer-${card.id}`}
+                    value={card.answer}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleFlashcardChange(card.id, 'answer', e.target.value)}
+                    disabled={isDeleted}
+                    placeholder="回答を入力してください"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/features/flashcard/components/flashcard-bulk-edit/index.ts
+++ b/packages/web/app/features/flashcard/components/flashcard-bulk-edit/index.ts
@@ -1,0 +1,1 @@
+export { FlashcardBulkEdit, type FlashcardBulkEditData } from "./flashcard-bulk-edit";

--- a/packages/web/app/routes/_content.content.$id_.flashcards.edit.tsx
+++ b/packages/web/app/routes/_content.content.$id_.flashcards.edit.tsx
@@ -1,0 +1,79 @@
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
+import { useParams } from "@remix-run/react";
+import { type FlashcardBulkEditData } from "~/features/flashcard/components/flashcard-bulk-edit";
+import { FlashcardBulkEdit } from "~/features/flashcard/components/flashcard-bulk-edit";
+import { getFlashcardsBySourceId } from "~/services/flashcard";
+import useSWR from "swr";
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "フラッシュカード一括編集 - Toi" },
+    { name: "description", content: "フラッシュカードを一括で編集できます" },
+  ];
+};
+
+export function clientLoader({ params }: LoaderFunctionArgs) {
+  return { sourceId: params.id! };
+}
+
+export default function FlashcardBulkEditPage() {
+  const { id: sourceId } = useParams<{ id: string }>();
+  
+  const { 
+    data: flashcards, 
+    error, 
+    isLoading,
+    mutate 
+  } = useSWR(
+    sourceId ? `flashcards-${sourceId}` : null,
+    () => sourceId ? getFlashcardsBySourceId(sourceId) : null
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+          <p className="text-muted-foreground">フラッシュカードを読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="text-center">
+          <p className="text-destructive mb-2">エラーが発生しました</p>
+          <p className="text-muted-foreground text-sm">{error.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!flashcards?.flashcards || flashcards.flashcards.length === 0) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="text-center">
+          <p className="text-muted-foreground">フラッシュカードがありません</p>
+        </div>
+      </div>
+    );
+  }
+
+  const bulkEditData: FlashcardBulkEditData[] = flashcards.flashcards.map((card) => ({
+    id: card.id,
+    question: card.question,
+    answer: card.answer,
+  }));
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <FlashcardBulkEdit 
+        sourceId={sourceId!}
+        flashcards={bulkEditData}
+        onUpdate={() => mutate()}
+      />
+    </div>
+  );
+}

--- a/packages/web/app/routes/_content.content.$id_.flashcards.tsx
+++ b/packages/web/app/routes/_content.content.$id_.flashcards.tsx
@@ -1,11 +1,13 @@
-import { useParams } from "@remix-run/react";
+import { useParams, Link } from "@remix-run/react";
 import useSWR from "swr";
 import { toast } from "sonner";
 import { getFlashcardsBySourceId } from "~/services/flashcard";
 import { FlashcardDeck, FlashcardHeader } from "~/features/flashcard/components";
 import { Spinner } from "~/components/ui/spinner";
+import { Button } from "~/components/ui/button";
 import { useContentDetail } from "~/features/content";
 import { useEffect } from "react";
+import { Edit } from "lucide-react";
 
 export default function ContentFlashcards() {
   const { id } = useParams();
@@ -75,6 +77,14 @@ export default function ContentFlashcards() {
       
       <div className="flex-1 overflow-auto">
         <div className="container mx-auto px-4 py-8">
+          <div className="mb-4 flex justify-end">
+            <Button asChild variant="outline">
+              <Link to={`/content/${id}/flashcards/edit`}>
+                <Edit className="w-4 h-4 mr-2" />
+                一括編集
+              </Link>
+            </Button>
+          </div>
           <FlashcardDeck flashcards={data.flashcards} />
         </div>
       </div>

--- a/packages/web/app/services/flashcard.ts
+++ b/packages/web/app/services/flashcard.ts
@@ -4,6 +4,8 @@ import {
   GetSourceFlashcardsResponse,
   PutFlashcardRequestBody,
   PutFlashcardResponse,
+  PutFlashcardsBulkRequestBody,
+  PutFlashcardsBulkResponse,
 } from "@toi/shared/src/schemas/source";
 import { api } from "./base";
 
@@ -24,6 +26,16 @@ export const updateFlashcard = async (
 ) => {
   return api.put<PutFlashcardResponse>(
     `/sources/${sourceId}/flashcards/${flashcardId}`,
+    body
+  );
+};
+
+export const updateFlashcardsBulk = async (
+  sourceId: string,
+  body: PutFlashcardsBulkRequestBody
+) => {
+  return api.put<PutFlashcardsBulkResponse>(
+    `/sources/${sourceId}/flashcards/bulk`,
     body
   );
 };


### PR DESCRIPTION
## Summary
- フラッシュカードの一括編集機能を実装
- APIエンドポイント（PUT /sources/:id/flashcards/bulk）を追加
- フラッシュカード一括編集用のUIコンポーネントを実装
- Remixルートを追加して一括編集ページを作成

## Test plan
- [ ] フラッシュカード一覧画面から一括編集ボタンをクリックできること
- [ ] 一括編集画面でフラッシュカードの質問・回答を編集できること
- [ ] 変更内容が正しく保存されること
- [ ] 削除マークしたフラッシュカードが除外されること
- [ ] 変更がない場合は保存ボタンが無効化されること

🤖 Generated with [Claude Code](https://claude.ai/code)