### PR TITLE
feat: フラッシュカードヘッダーのUI改修

### DIFF
--- a/packages/web/app/features/flashcard/components/flashcard-header/flashcard-header.tsx
+++ b/packages/web/app/features/flashcard/components/flashcard-header/flashcard-header.tsx
@@ -3,6 +3,8 @@ import { Settings } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "~/components/ui/dialog";
 import { LearningSettingsDialog } from "../learning-settings-dialog";
+import { useScroll } from "~/hooks/use-scroll";
+import { cn } from "~/lib/utils";
 
 type FlashcardHeaderProps = {
   title: string;
@@ -10,25 +12,36 @@ type FlashcardHeaderProps = {
 
 export function FlashcardHeader({ title }: FlashcardHeaderProps) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const isScrolled = useScroll();
 
   return (
-    <div className="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
+    <div 
+      className={cn(
+        "top-0 z-10 px-4 py-3 transition-all duration-200",
+        // Mobile: fixed positioning, Desktop: sticky positioning
+        "fixed md:sticky",
+        // Transparent background with blur when scrolled
+        isScrolled ? "bg-white/80 backdrop-blur-md" : "bg-transparent",
+        // Border only when scrolled
+        isScrolled && "border-b border-gray-200/50"
+      )}
+    >
       <div className="flex items-center justify-center relative md:justify-between">
         {/* Title - centered on mobile, left-aligned on desktop with proper truncation */}
         <h1 className="text-xl font-bold text-gray-800 truncate text-center md:text-left max-w-[calc(100%-4rem)] md:max-w-none">
           {title}
         </h1>
         
-        {/* Settings icon - fixed at top right */}
+        {/* Settings icon - styled like hamburger menu */}
         <Dialog open={isSettingsOpen} onOpenChange={setIsSettingsOpen}>
           <DialogTrigger asChild>
             <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 w-8 p-0 absolute right-0 top-1/2 transform -translate-y-1/2 md:relative md:right-auto md:top-auto md:transform-none"
+              variant="outline"
+              size="icon"
+              className="p-1.5 size-10 bg-card/30 backdrop-blur-md absolute right-0 top-1/2 transform -translate-y-1/2 md:relative md:right-auto md:top-auto md:transform-none"
               aria-label="学習設定"
             >
-              <Settings className="h-4 w-4" />
+              <Settings className="w-5 h-5" />
             </Button>
           </DialogTrigger>
           <DialogContent className="sm:max-w-md">

--- a/packages/web/app/hooks/use-scroll.ts
+++ b/packages/web/app/hooks/use-scroll.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export function useScroll() {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrolled = window.scrollY > 0;
+      setIsScrolled(scrolled);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    handleScroll(); // Check initial scroll position
+
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return isScrolled;
+}

--- a/packages/web/app/routes/_content.content.$id_.flashcards.tsx
+++ b/packages/web/app/routes/_content.content.$id_.flashcards.tsx
@@ -85,7 +85,7 @@ export default function ContentFlashcards() {
     <div className="flex flex-col h-screen">
       <FlashcardHeader title={contentDetail?.title ?? "タイトル未設定"} />
       
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 overflow-auto pt-[60px] md:pt-0">
         <div className="container mx-auto px-4 py-8">
           <div className="mb-4 flex justify-end">
             <Button asChild variant="outline">


### PR DESCRIPTION
## Summary
- モバイル時はfixed、デスクトップ時はstickyポジションに変更
- スクロール時に透明背景とblur効果を追加  
- 設定ボタンをハンバーガーメニューと同じスタイルに統一

## Test plan
- [ ] モバイルでヘッダーが画面上部に固定されることを確認
- [ ] デスクトップでヘッダーがstickyポジションで動作することを確認
- [ ] スクロール時にblur効果とボーダーが適用されることを確認
- [ ] 設定ボタンがハンバーガーメニューと同じスタイルであることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)